### PR TITLE
Expose FlagsClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { FlagsConfig, FlagValue } from './client/FlagsClient';
+import FlagsClient, { FlagsConfig, FlagValue } from './client/FlagsClient';
 import FeatureFlag, { FeatureFlagComponentProps } from './components/FeatureFlag';
 import FlagsContext from './components/FlagsContext';
 import FlagsProvider, { FlagsProviderProps } from './components/FlagsProvider';
@@ -13,4 +13,5 @@ export {
   useFlag,
   FlagsConfig,
   FlagValue,
+  FlagsClient,
 };


### PR DESCRIPTION
Exposing the client would allow reuse of `FlagsClient` on the server side, for example on Next.js applications [API routes](https://nextjs.org/docs/api-routes/introduction), ie:

```ts
// pages/api/user.ts
import { FlagsClient } from 'react-unleash-flags';
import flagsConfig from '../shared/config/flagsConfig';

const flags = new FlagsClient(flagsConfig);

export default async (req, res) => {
  await flags.init();
  
  const user = { name: "Rick" };

  if(flags.getFlag('userAge')) {
    user.age = 34;
  }

  res.json(user);
}
```