### PR TITLE
Added support for toggles

### DIFF
--- a/src/client/FlagsClient.ts
+++ b/src/client/FlagsClient.ts
@@ -68,7 +68,8 @@ class FlagsClient {
 
     try {
       const json = await response.json();
-      this.flags = json.features;
+      // support unleash service (features) or unleash proxy responses (toggles)
+      this.flags = json.features || json.toggles;
     } catch {
       // no json, return nothing
       this.flags = [];


### PR DESCRIPTION
Proxy uses `toggles` as standard, so to support this with react-unleash-flags for now, we'd like to support both features and toggles.

https://github.com/Unleash/unleash-proxy-client-js/blob/c5f3e3f8bebb2ab11e959108fe3a6d7fee3c5200/src/index.ts#L56